### PR TITLE
Add an argument parser

### DIFF
--- a/arg.c
+++ b/arg.c
@@ -16,6 +16,15 @@ void help(const char *program_name) {
    printf("  -h, --help    display this help message\n");
 }
 
+void parse_positional(char *positional, options *opts) {
+   if (!opts->adapter)
+      opts->adapter = positional;
+   else {
+      eprintf("Unexpected positional argument %s\n", positional);
+      exit(EXIT_FAILURE);
+   }
+}
+
 options parse_args(char **argv) {
    options opt = {.help = false, .program_name = NULL, .adapter = NULL};
    if (*argv == NULL) {
@@ -54,22 +63,11 @@ options parse_args(char **argv) {
          ++argv;
          break;
       } else {
-         if (!opt.adapter)
-            opt.adapter = *argv;
-         else {
-            eprintf("Unexpected positional argument %s\n", *argv);
-            exit(EXIT_FAILURE);
-         }
+         parse_positional(*argv, &opt);
       }
    }
    while (*argv) {
-      // FIXME: Reduce code duplication here!
-      if (!opt.adapter)
-         opt.adapter = *argv;
-      else {
-         eprintf("Unexpected positional argument %s\n", *argv);
-         exit(EXIT_FAILURE);
-      }
+      parse_positional(*argv++, &opt);
    }
 
    return opt;

--- a/arg.c
+++ b/arg.c
@@ -1,0 +1,76 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "arg.h"
+#include "utils.h"
+
+void usage(const char *program_name) {
+   printf("USAGE:\n");
+   printf("  %s [--help] <network_device>\n", program_name);
+}
+void help(const char *program_name) {
+   usage(program_name);
+   printf("\n");
+   printf("OPTIONS:\n");
+   printf("  -h, --help    display this help message\n");
+}
+
+options parse_args(char **argv) {
+   options opt = {.help = false, .program_name = NULL, .adapter = NULL};
+   if (*argv == NULL) {
+      eprintf("Running this program without argv[0] is unsupported!\n");
+      exit(EXIT_FAILURE);
+   }
+   opt.program_name = *argv;
+
+   while (*++argv) {
+      // Short options
+      // This parser supports chaining options like -abcd!
+      if (**argv == '-' && (*argv)[1] != '-') {
+         const char *short_options = *argv;
+
+         while (*++short_options) {
+            switch (*short_options) {
+            // -h
+            case 'h':
+               opt.help = true;
+               break;
+            default:
+               eprintf("Unknown argument -%c\n", *short_options);
+               exit(EXIT_FAILURE);
+            }
+         }
+
+         continue;
+      }
+
+      // Long options
+      if (strcmp(*argv, "--help") == 0) {
+         opt.help = true;
+      } else if (strcmp(*argv, "--") == 0) {
+         // If we encounter a "--" we stop parsing and treat further arguments
+         // as non-flag arguemnts
+         ++argv;
+         break;
+      } else {
+         if (!opt.adapter)
+            opt.adapter = *argv;
+         else {
+            eprintf("Unexpected positional argument %s\n", *argv);
+            exit(EXIT_FAILURE);
+         }
+      }
+   }
+   while (*argv) {
+      // FIXME: Reduce code duplication here!
+      if (!opt.adapter)
+         opt.adapter = *argv;
+      else {
+         eprintf("Unexpected positional argument %s\n", *argv);
+         exit(EXIT_FAILURE);
+      }
+   }
+
+   return opt;
+}

--- a/arg.h
+++ b/arg.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <stdbool.h>
+
+typedef struct {
+   const char *program_name;
+   const char *adapter;
+   bool help;
+} options;
+
+void usage(const char *program_name);
+void help(const char *program_name);
+options parse_args(char **argv);

--- a/main.c
+++ b/main.c
@@ -27,7 +27,7 @@ int main(int argc, char **argv) {
    }
 
    if (!opt.adapter) {
-      eprintf("No network adapter provieded\n");
+      eprintf("No network adapter provided\n");
       exit(EXIT_FAILURE);
    }
 

--- a/main.c
+++ b/main.c
@@ -2,7 +2,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdint.h>
+
+#include "arg.h"
+#include "utils.h"
 
 void readBytes(FILE *fp, uintmax_t *out) {
    char *ptr;
@@ -17,10 +19,31 @@ void readBytes(FILE *fp, uintmax_t *out) {
    memset(buffer, 0, 128);
 }
 
-int main()
-{
-   FILE *fprx = fopen("/sys/class/net/enp4s0/statistics/rx_bytes", "r");
-   FILE *fptx = fopen("/sys/class/net/enp4s0/statistics/tx_bytes", "r");
+int main(int argc, char **argv) {
+   options opt = parse_args(argv);
+   if (opt.help) {
+      help(opt.program_name);
+      exit(EXIT_SUCCESS);
+   }
+
+   if (!opt.adapter) {
+      eprintf("No network adapter provieded\n");
+      exit(EXIT_FAILURE);
+   }
+
+   const char *name = opt.adapter;
+   // len("/sys/class/net/") = 15
+   char adapter_dir[15 + strlen(name) + 1];
+   sprintf(adapter_dir, "/sys/class/net/%s", name);
+
+   // len("/sys/class/net/") = 15
+   // len("/statistics/_x_bytes") = 20
+   char path[15 + strlen(name) + 20 + 1];
+   sprintf(path, "%s/statistics/rx_bytes", adapter_dir);
+   FILE *fprx = fopen(path, "r");
+   sprintf(path, "%s/statistics/tx_bytes", adapter_dir);
+   FILE *fptx = fopen(path, "r");
+
    uintmax_t rxbytes;
    uintmax_t txbytes;
 

--- a/main.c
+++ b/main.c
@@ -1,9 +1,10 @@
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
 
-void readBytes(FILE *fp, __uintmax_t* out ) {
+void readBytes(FILE *fp, uintmax_t *out) {
    char *ptr;
    char buffer[128];
    if (fp == NULL) {
@@ -22,15 +23,14 @@ int main()
    FILE *fptx = fopen("/sys/class/net/enp4s0/statistics/tx_bytes", "r");
    uintmax_t rxbytes;
    uintmax_t txbytes;
-  
+
    readBytes(fprx, &rxbytes);
    readBytes(fptx, &txbytes);
 
-   printf("Data downloaded: %lluMB\n",rxbytes/1000000);
-   printf("Data uploaded: %lluMB\n",txbytes/1000000);
-   printf("Raw bytes downloaded: %llu\n",rxbytes);
-   printf("Raw bytes uploaded: %llu\n",txbytes);
-
+   printf("Data downloaded: %luMB\n", rxbytes / 1000000);
+   printf("Data uploaded: %luMB\n", txbytes / 1000000);
+   printf("Raw bytes downloaded: %lu\n", rxbytes);
+   printf("Raw bytes uploaded: %lu\n", txbytes);
 
    return 0;
 }

--- a/utils.h
+++ b/utils.h
@@ -1,0 +1,2 @@
+#pragma once
+#define eprintf(fmt, ...) fprintf(stderr, fmt, ##__VA_ARGS__);


### PR DESCRIPTION
This PR adds in a simple argument parser and a "--help" flag.

The parser support short style flags like "-h" and also chaining them like this: "-lh".
Simple long flags like "--help" are also supported.
After a "--" parsing stops and all arguments are treated as positional.