### PR TITLE
Makefile: Don't force `clang` on everyone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SRC = main.c arg.c
-CC = clang
+CC ?= clang
 
 all: cnetstat 
 


### PR DESCRIPTION
This PR changes one letter in the Makefile to allow building on systems with compilers other than clang.