### PR TITLE
Makefile: Rebuild on source change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CC ?= clang
 
 all: cnetstat 
 
-cnetstat:
+cnetstat: $(SRC)
 	$(CC) -O3 -Wall $(SRC) -o cnetstat -I.
 
 clean:


### PR DESCRIPTION
Previously the Makefile would not rebuild the program even if a source file has changed.