### PR TITLE
Fix `find_adapter` and replace all occurances of `adapter` with `interface`

### DIFF
--- a/arg.c
+++ b/arg.c
@@ -23,8 +23,8 @@ void help(const char *program_name) {
 }
 
 void parse_positional(char *positional, options *opts) {
-    if (!opts->adapter)
-       opts->adapter = positional;
+    if (!opts->interface)
+       opts->interface = positional;
     else {
        eprintf("Unexpected positional argument %s\n", positional);
        exit(EXIT_FAILURE);
@@ -32,7 +32,7 @@ void parse_positional(char *positional, options *opts) {
 }
 
 options parse_args(char **argv) {
-    options opt = {.program_name = NULL, .adapter = NULL, .conversion = 0, .raw=false, .help=false, .wipe=false};
+    options opt = {.program_name = NULL, .interface = NULL, .conversion = 0, .raw=false, .help=false, .wipe=false};
     if (*argv == NULL) {
        eprintf("Running this program without argv[0] is unsupported!\n");
        exit(EXIT_FAILURE);

--- a/arg.h
+++ b/arg.h
@@ -3,7 +3,7 @@
 
 typedef struct {
    const char *program_name;
-   const char *adapter;
+   const char *interface;
    unsigned short int conversion;
    bool raw;
    bool help;

--- a/main.c
+++ b/main.c
@@ -61,27 +61,31 @@ int main(int argc, char **argv) {
        exit(EXIT_SUCCESS);
     }
 
-    bool adapter_free = false;
-    if (!opt.adapter) {
-        opt.adapter = find_adapter();
-        adapter_free = true;
+    bool interface_free = false;
+    if (opt.interface == NULL) {
+        opt.interface = find_interface();
+        if(opt.interface == NULL) {
+            fprintf(stderr, "Could not find active interface\n");
+            exit(EXIT_FAILURE);
+        }
+        interface_free = true;
     }
 
-    const char *name = opt.adapter;
+    const char *name = opt.interface;
     // len("/sys/class/net/") = 15
-    char adapter_dir[15 + strlen(name) + 1];
-    sprintf(adapter_dir, "/sys/class/net/%s", name);
+    char interface_dir[15 + strlen(name) + 1];
+    sprintf(interface_dir, "/sys/class/net/%s", name);
 
     // len("/sys/class/net/") = 15
     // len("/statistics/_x_bytes") = 20
     char path[15 + strlen(name) + 20 + 1];
-    sprintf(path, "%s/statistics/rx_bytes", adapter_dir);
+    sprintf(path, "%s/statistics/rx_bytes", interface_dir);
     FILE *rxf = fopen(path, "r");
     if(rxf == NULL) {
         eprintf("Could not open %s\n", path);
         exit(EXIT_FAILURE);
     }
-    sprintf(path, "%s/statistics/tx_bytes", adapter_dir);
+    sprintf(path, "%s/statistics/tx_bytes", interface_dir);
     FILE *txf = fopen(path, "r");
     if(txf == NULL) {
         eprintf("Could not open %s\n", path);
@@ -125,8 +129,8 @@ int main(int argc, char **argv) {
        exit(EXIT_FAILURE);
     }
     
-    if(adapter_free)
-        free((void*)opt.adapter);
+    if(interface_free)
+        free((void*)opt.interface);
 
     return 0;
 }

--- a/main.c
+++ b/main.c
@@ -61,10 +61,10 @@ int main(int argc, char **argv) {
        exit(EXIT_SUCCESS);
     }
 
+    bool adapter_free = false;
     if (!opt.adapter) {
-        // NOTE: This theoretically leaks memory but it lives throught the whole program
-        //       so it isn't worth freeing it.
-       opt.adapter = find_adapter();
+        opt.adapter = find_adapter();
+        adapter_free = true;
     }
 
     const char *name = opt.adapter;
@@ -124,6 +124,9 @@ int main(int argc, char **argv) {
        perror("Failed to close stat file");
        exit(EXIT_FAILURE);
     }
+    
+    if(adapter_free)
+        free((void*)opt.adapter);
 
     return 0;
 }

--- a/utils.c
+++ b/utils.c
@@ -1,5 +1,3 @@
-#define _GNU_SOURCE
-
 #include <pwd.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -11,6 +9,9 @@
 #include <string.h>
 #include <dirent.h>
 #include <stdio.h>
+#include <stddef.h>
+#include <stdarg.h>
+#include <ctype.h>
 
 #include "utils.h"
 
@@ -20,6 +21,49 @@ char* get_user_name() {
     if (!pw)
         exit(EXIT_FAILURE);
     return pw->pw_name;
+}
+
+void perrorf(const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    vfprintf(stderr, fmt, ap);
+    va_end(ap);
+    fprintf(stderr, ": %s\n", strerror(errno));
+}
+
+ssize_t getword(FILE* file, char** outptr) {
+    int ret;
+
+    while((ret = fgetc(file)) != EOF && isspace(ret))
+        if(ret < 0)
+            return -1;
+
+    size_t len = 0;
+    size_t cap = 64;
+    char* word = malloc(cap);
+
+    if(ret != EOF)
+        word[len++] = ret;
+    else {
+        *outptr = word;
+        return 0;
+    }
+
+    while((ret = fgetc(file)) != EOF) {
+        if(ret < 0) {
+            free(word);
+            return -1;
+        }
+        if(isspace(ret))
+            break;
+        if(len >= cap - 1)
+            word = realloc(word, cap *= 2);
+        word[len++] = ret;
+    }
+
+    word[len] = 0;
+    *outptr = word;
+    return len;
 }
 
 int mkdirp(char* path, mode_t mode) {
@@ -52,35 +96,73 @@ char* find_adapter() {
 
     struct dirent *entry;
     while ((entry = readdir(dir))) {
-        char *buf;
-        asprintf(&buf, "/sys/class/net/%s/device", entry->d_name);
-        if (access(buf, F_OK) == 0) {
-            // len("/sys/class/net/") = 15
-            // len("/operstate") = 10
-            char path[15 + strlen(entry->d_name) + 10];
-            sprintf(path, "/sys/class/net/%s/operstate", entry->d_name);
-            FILE *tmp = fopen(path, "r");
+        if(strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+            continue;
 
-            int ret;
-            if ((ret = fscanf(tmp, "%s", buf)) != 1) {
-                eprintf("Failed to read saved stats: %s\n", ret < 0 ? strerror(errno) : "Invalid format");
-                exit(EXIT_FAILURE);
-            }
-
-            if (strcmp(buf, "up\n")) {
-                char* cpy = strdup(entry->d_name);
-                free(buf);
-                free(dir);
-                fclose(tmp);
-                return cpy;
-            }
+        // len("/sys/class/net/") = 15
+        // len("/type") = 5
+        char type_path[15 + strlen(entry->d_name) + 5 + 1];
+        sprintf(type_path, "/sys/class/net/%s/type", entry->d_name);
+        FILE *type_file = fopen(type_path, "r");
+        if (!type_file) {
+            perrorf("Failed to open %s", type_path);
+            exit(EXIT_FAILURE);
         }
-        free(buf);
+
+        char *type_str;
+        if (getword(type_file, &type_str) < 0) {
+            perrorf("Failed to read %s", type_path);
+            exit(EXIT_FAILURE);
+        }
+
+        char* endptr;
+        long type = strtol(type_str, &endptr, 10);
+        if (endptr == type_str || *endptr != '\0') {
+            perrorf("Failed to parse %s as number", type_path);
+            exit(EXIT_FAILURE);
+        }
+
+
+        // Ignore virtual and loopback interfaces (hopefully this is right)
+        // https://elixir.bootlin.com/linux/v5.18.3/source/include/uapi/linux/if_arp.h#L30
+        if((type >= 768 && type <= 772)
+           || (type >= 777 && type <= 779)
+           || type == 783
+        ) {
+            free(type_str);
+            fclose(type_file);
+            continue;
+        }
+        free(type_str);
+
+        // len("/sys/class/net/") = 15
+        // len("/operstate") = 10
+        char operstate_path[15 + strlen(entry->d_name) + 10 + 1];
+        sprintf(operstate_path, "/sys/class/net/%s/operstate", entry->d_name);
+        FILE *tmp = fopen(operstate_path, "r");
+        if (!tmp) {
+            perrorf("Failed to open %s", operstate_path);
+            exit(EXIT_FAILURE);
+        }
+
+        char* word;
+        if(getword(tmp, &word) < 0) {
+            perrorf("Failed to read from %s", operstate_path);
+            exit(EXIT_FAILURE);
+        }
+
+        if (strcmp(word, "up") == 0) {
+            char* cpy = strdup(entry->d_name);
+            free(dir);
+            free(word);
+            fclose(tmp);
+            return cpy;
+        }
+        free(word);
     }
 
     free(dir);
-    eprintf("No network adapter found/provided\n");
-    exit(EXIT_FAILURE);
+    return NULL;
 }
 
 time_t get_boot_time() {

--- a/utils.c
+++ b/utils.c
@@ -79,15 +79,12 @@ int mkdirp(char* path, mode_t mode) {
 
         *ptr = '/';
     }
-    if(mkdir(path, mode) < 0) {
-        if(errno != EEXIST) {
+    if(mkdir(path, mode) < 0 && errno != EEXIST)
             return -1;
-        }
-    }
     return 0;
 }
 
-char* find_adapter() {
+char* find_interface() {
     DIR *dir = opendir("/sys/class/net");
     if (!dir) {
         perror("Failed to open /sys/class/net directory");

--- a/utils.h
+++ b/utils.h
@@ -32,7 +32,7 @@ ssize_t getword(FILE* file, char** wordptr);
   * Returns the name of the first active interface.
   * Ignores loopback and virtual interfaces.
   **/
-char* find_adapter();
+char* find_interface();
 
 /**
  * Gets the time the system was booted at in seconds.

--- a/utils.h
+++ b/utils.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <sys/types.h>
+#include <stdio.h>
 #include <time.h>
 
 #define eprintf(fmt, ...) fprintf(stderr, fmt, ##__VA_ARGS__)
@@ -7,12 +8,29 @@
 char *get_user_name();
 
 /**
- * Just like mkdir(2) but recursively creates parent directories.
+ * Like mkdir(2) but recursively creates parent directories.
  **/
 int mkdirp(char *path, mode_t mode);
 
 /**
-  * Finds the adapter name to use.
+ * Like perror(3) but accepts a format string.
+ */
+void perrorf(const char *fmt, ...);
+
+/**
+ * Reads one word from a file.
+ * A word is defined as a sequence of non-whitespace characters.
+ * Whitespace is defined as characters for which isspace(3) returns true.
+ *
+ * @param file The file to read from.
+ * @param wordptr A pointer to a char* that will be set to the word (has to be freed with free()).
+ * @return Word length on success, -1 on error.
+ */
+ssize_t getword(FILE* file, char** wordptr);
+
+/**
+  * Returns the name of the first active interface.
+  * Ignores loopback and virtual interfaces.
   **/
 char* find_adapter();
 


### PR DESCRIPTION
`find_adapter` was broken, here is why:
- it would actually use `strcmp(3)` incorrectly
- it would overflow a buffer if `/sys/class/net/<interface>/operstate` contained a string longer than `"/sys/class/net/<interface>/device"` which while impossible on current kernel versions *may* be possible some time in the future, even though this is very unlikely I consider this a bug
- it would overflow a buffer by one byte due to omitting the terminating null byte in the buffer's length calculation
- it didn't ignore loopback interfaces which is pretty unintuitive

All these issues are fixed by this PR.

Also the name `interface` is probably more appropriate than `adapter` since everyone else calls them interfaces.